### PR TITLE
Fix: Resolve overlap between player name and score display

### DIFF
--- a/style.css
+++ b/style.css
@@ -181,20 +181,12 @@ body {
     z-index: 2;
 }
 
-
-.ali-nasser {
-    font-size: 1.5rem; /* Decreased font size */
-    color: var(--neon-pink);
-    text-shadow: var(--glow) var(--neon-purple);
-    letter-spacing: 2px;
-    animation: pulse 1.5s infinite alternate;
-}
 /* Player Name Styles */
 #player-name {
     position: absolute;
     top: 10px;
-    right: 10px;
-    font-size: 1.5rem; /* Ensure the font size is consistent */
+    left: 10px;
+    font-size: 0.8rem; /* Ensure the font size is consistent */
     color: var(--neon-pink);
     text-shadow: var(--glow) var(--neon-purple);
     letter-spacing: 2px;


### PR DESCRIPTION
The player name text was overlapping with the score.

This commit adjusts the CSS for the #player-name element:
- Repositions it to the top-left corner (top: 10px; left: 10px;).
- Reduces its font size to 0.8rem.
- Removes the redundant .ali-nasser CSS class styles, consolidating into the #player-name ID selector.

These changes ensure the player name and score are displayed clearly without visual conflict.